### PR TITLE
show nonce, sender, extrinsic hash, events for EVM txs

### DIFF
--- a/src/views/ExtrinsicDetail/index.vue
+++ b/src/views/ExtrinsicDetail/index.vue
@@ -413,11 +413,7 @@ export default {
         const evmTx = res?.call_module === 'ethereum' && res?.call_module_function === 'transact';
         if (res.signature || evmTx) {
             this.showAdditionalInfo = true;
-            if (evmTx) {
-                this.nonce = res?.params[0]?.value?.eip1559?.nonce;
-            } else {
-                this.nonce = res.nonce;
-            }
+            this.nonce = evmTx ? res?.params[0]?.value?.eip1559?.nonce : res.nonce;
         }
         this.extrinsicNum = res.extrinsic_index;
         this.isLoading = false;

--- a/src/views/ExtrinsicDetail/index.vue
+++ b/src/views/ExtrinsicDetail/index.vue
@@ -44,7 +44,7 @@
               }}</router-link>
             </div>
           </div>
-          <div class="info-item" v-if="extrinsicInfo.signature">
+          <div class="info-item" v-if="showAdditionalInfo">
             <div class="label">{{ $t("extrinsic_hash") }}</div>
             <div class="value copy align-items-center">
               <div>{{ extrinsicInfo.extrinsic_hash }}</div>
@@ -66,7 +66,7 @@
             <div class="label">{{ $t("call") }}</div>
             <div class="value">{{ extrinsicInfo.call_module_function }}</div>
           </div>
-          <div class="info-item" v-if="extrinsicInfo.signature">
+          <div class="info-item" v-if="showAdditionalInfo">
             <div class="label">{{ $t("sender") }}</div>
             <div class="value account link copy align-items-center">
               <div class="icon identicon">
@@ -139,9 +139,9 @@
               ></balances>
             </div>
           </div>
-          <div class="info-item" v-if="extrinsicInfo.signature">
+          <div class="info-item" v-if="showAdditionalInfo">
             <div class="label">{{ $t("nonce") }}</div>
-            <div class="value">{{ extrinsicInfo.nonce }}</div>
+            <div class="value">{{ nonce }}</div>
           </div>
           <div class="info-item">
             <div class="label">{{ $t("result") }}</div>
@@ -199,7 +199,7 @@
         <div
           class="extrinsic-extrinsic-event-log subscan-card"
           v-loading="isLoading"
-          v-if="extrinsicInfo.signature"
+          v-if="showAdditionalInfo"
         >
           <el-tabs v-model="activeTab">
             <el-tab-pane
@@ -305,6 +305,8 @@ export default {
   data() {
     return {
       extrinsicNum: "",
+      nonce: 0,
+      showAdditionalInfo: false,
       extrinsicInfo: {
         success: true
       },
@@ -408,6 +410,15 @@ export default {
           );
         }
         this.extrinsicInfo = res;
+        const evmTx = res?.call_module === 'ethereum' && res?.call_module_function === 'transact';
+        if (res.signature || evmTx) {
+            this.showAdditionalInfo = true;
+            if (evmTx) {
+                this.nonce = res?.params[0]?.value?.eip1559?.nonce;
+            } else {
+                this.nonce = res.nonce;
+            }
+        }
         this.extrinsicNum = res.extrinsic_index;
         this.isLoading = false;
       } catch (err) {


### PR DESCRIPTION
Closes https://github.com/cennznet/uncover-frontend/issues/27
For EVM txs we don't get the signature. This PR will show the additional info
<img width="1792" alt="Screen Shot 2022-05-17 at 3 43 32 PM" src="https://user-images.githubusercontent.com/29415595/168724179-f5e3f3fb-eb75-4284-8b45-ec14abbdfae2.png">
<img width="1792" alt="Screen Shot 2022-05-17 at 3 43 38 PM" src="https://user-images.githubusercontent.com/29415595/168724196-be72d7cf-d196-4e8f-b67c-3506adbd70f5.png">
