### PR TITLE
Add `.nvmrc` and `engines.node` to lock down node version

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/fermium

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint"
   },
+  "engines": {
+    "node": "14"
+  },
   "dependencies": {
     "@polkadot/util": "^1.1.1",
     "@polkadot/util-crypto": "^1.1.1",


### PR DESCRIPTION
Trying to setup a new project on Vercel and this repo didn't pass the initial build because Vercel used Node 16 to build but this project is not compatible with it.