### PR TITLE
Release/v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [1.0.3] - 2022-06-21
+
+- Remove the unavailable cover for the Pie Chart
+
 ## [1.0.3] - 2022-06-17
 
 - Make couple UI adjustments with recent changes to how balances are fetched from API

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cennznet/uncover-frontend",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "license": "ISC",
   "scripts": {
     "dev": "vue-cli-service serve",

--- a/src/views/Dashboard/chartPie.vue
+++ b/src/views/Dashboard/chartPie.vue
@@ -535,16 +535,5 @@ export default {
       height: 156px;
     }
   }
-
-  // .chart-cover {
-  //   position: absolute;
-  //   inset:0;
-  //   background: rgba(255, 255, 255, 0.95);
-  //   border-radius: 4px;
-  //   display: flex;
-  //   align-items: center;
-  //   justify-content: center;
-  //   font-size: 1.2em;
-  // }
 }
 </style>

--- a/src/views/Dashboard/chartPie.vue
+++ b/src/views/Dashboard/chartPie.vue
@@ -7,9 +7,6 @@
       </div>
     </div>
     <div class="chart-content subscan-card" ref="chart"></div>
-    <div class="chart-cover">
-      <p>Temporarily unavailable</p>
-    </div>
   </div>
 </template>
 
@@ -539,15 +536,15 @@ export default {
     }
   }
 
-  .chart-cover {
-    position: absolute;
-    inset:0;
-    background: rgba(255, 255, 255, 0.95);
-    border-radius: 4px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1.2em;
-  }
+  // .chart-cover {
+  //   position: absolute;
+  //   inset:0;
+  //   background: rgba(255, 255, 255, 0.95);
+  //   border-radius: 4px;
+  //   display: flex;
+  //   align-items: center;
+  //   justify-content: center;
+  //   font-size: 1.2em;
+  // }
 }
 </style>


### PR DESCRIPTION
## Why

Revert the change from the Pie Chart since `v1.0.3`

## What is changing

- Remove the unavailable cover for the Pie Chart